### PR TITLE
Display a max age of 60

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -5954,7 +5954,7 @@ void LivingLifePage::handleOurDeath() {
         mDeathReason = stringDuplicate( "" );
         }
     
-    int years = (int)floor( computeCurrentAge( getOurLiveObject() ) );
+    int years = fmin(60,(int)floor( computeCurrentAge( getOurLiveObject() ) ));
 
     char *ageString;
     


### PR DESCRIPTION
The age calculator can present an age of >60 (such as 163) if you put your computer to sleep during a game and then wake it up. It looks like it just calculates the age at the time of handling the death, not the actual moment of death. Otherwise it looks like the player was way older than they should be.