### PR TITLE
Improve gitignore coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,25 @@
 
 *.o
 *.dep
+*.dep2
 *~
 *.orig
+Makefile*
 
+gameSource/OneLife
 gameSource/testUser/*
 gameSource/testUser2/*
 gameSource/recordedGames/*
 gameSource/screenShots/*
+
+server/OneLifeServer
+server/log.txt
+server/recentPlacements.txt
+server/*.db
+server/backups/
+server/failureLog/
+server/foodLog/
+server/lifeLog/
+server/categories
+server/objects
+server/transitions


### PR DESCRIPTION
Running a server currently creates a lot of unstaged cruft. This doesn't completely eliminate it - after adding these lines, I still have:

```
server/settings/nextPlayerID.ini
server/settings/sequenceNumber.ini
```

I'll address that in a second PR.