### PR TITLE
Allow configuration of server paths with environment variables

### DIFF
--- a/server/backup.cpp
+++ b/server/backup.cpp
@@ -1,4 +1,5 @@
 #include "backup.h"
+#include "env.h"
 
 
 
@@ -45,7 +46,7 @@ void backupDBFile( const char *inFileNamePrefix, char *inTimeFileNamePart,
                    File *inBackupFolder ) {
     char *fileName = autoSprintf( "%s.db", inFileNamePrefix );
     
-    File dbFile( NULL, fileName );
+    File dbFile( getEnvDBPath(), fileName );
 
     delete [] fileName;
 
@@ -112,7 +113,7 @@ void checkBackup() {
                                  timeStruct.tm_min,
                                  timeStruct.tm_sec );
 
-                File backupFolder( NULL, "backups" );
+                File backupFolder( getEnvDBPath(), "backups" );
                 
                 if( ! backupFolder.exists() ) {
                     Directory::makeDirectory( &backupFolder );

--- a/server/env.cpp
+++ b/server/env.cpp
@@ -1,0 +1,52 @@
+#include "minorGems/io/file/Path.h"
+#include "minorGems/util/log/AppLog.h"
+
+#include <cstdlib>
+
+static char *logPath;
+static char *dbPath;
+static char *settingsPath;
+
+void readEnv() {
+    if ( getenv("OHOL_LOG_PATH") ){
+        logPath = getenv("OHOL_LOG_PATH");
+        AppLog::infoF( "Using %s as log path", logPath );
+        }
+
+    if ( getenv("OHOL_DB_PATH") ){
+        dbPath = getenv("OHOL_DB_PATH");
+        AppLog::infoF( "Using %s as db path", dbPath );
+        }
+
+    if ( getenv("OHOL_SETTINGS_PATH") ){
+        settingsPath = getenv("OHOL_SETTINGS_PATH");
+        AppLog::infoF( "Using %s as settings path", settingsPath );
+        }
+}
+
+Path *getEnvLogPath() {
+    if ( logPath ) {
+        return new Path( logPath );
+        }
+    else {
+        return NULL;
+        }
+    }
+
+Path *getEnvDBPath() {
+    if ( dbPath ) {
+        return new Path( dbPath );
+        }
+    else {
+        return NULL;
+        }
+    }
+
+Path *getEnvSettingsPath() {
+    if ( settingsPath ) {
+        return new Path( settingsPath );
+        }
+    else {
+        return NULL;
+        }
+    }

--- a/server/env.h
+++ b/server/env.h
@@ -1,0 +1,12 @@
+#include "minorGems/io/file/Path.h"
+
+void readEnv();
+
+
+Path *getEnvLogPath();
+
+
+Path *getEnvDBPath();
+
+
+Path *getEnvSettingsPath();

--- a/server/failureLog.cpp
+++ b/server/failureLog.cpp
@@ -1,6 +1,7 @@
 
 #include <stdio.h>
 
+#include "env.h"
 
 #include "minorGems/util/stringUtils.h"
 #include "minorGems/util/SimpleVector.h"
@@ -30,8 +31,8 @@ static FILE *openCurrentLogFile() {
     
     strftime( fileName, 99, "%Y_%m%B_%d_%A.txt", timeStruct );
 
-    File logDir( NULL, "failureLog" );
-    
+    File logDir( getEnvLogPath(), "failureLog" );
+
     if( ! logDir.exists() ) {
         Directory::makeDirectory( &logDir );
         }

--- a/server/foodLog.cpp
+++ b/server/foodLog.cpp
@@ -1,6 +1,7 @@
 
 #include <stdio.h>
 
+#include "env.h"
 
 #include "minorGems/util/stringUtils.h"
 #include "minorGems/io/file/File.h"
@@ -29,8 +30,8 @@ static FILE *openCurrentLogFile() {
     
     strftime( fileName, 99, "%Y_%m%B_%d_%A.txt", timeStruct );
 
-    File logDir( NULL, "foodLog" );
-    
+    File logDir( getEnvLogPath(), "foodLog" );
+
     if( ! logDir.exists() ) {
         Directory::makeDirectory( &logDir );
         }

--- a/server/lifeLog.cpp
+++ b/server/lifeLog.cpp
@@ -3,6 +3,7 @@
 
 #include "map.h"
 #include "playerStats.h"
+#include "env.h"
 
 
 
@@ -34,8 +35,8 @@ static FILE *openCurrentLogFile() {
     
     strftime( fileName, 99, "%Y_%m%B_%d_%A.txt", timeStruct );
 
-    File logDir( NULL, "lifeLog" );
-    
+    File logDir( getEnvLogPath(), "lifeLog" );
+
     if( ! logDir.exists() ) {
         Directory::makeDirectory( &logDir );
         }

--- a/server/makeFileList
+++ b/server/makeFileList
@@ -41,6 +41,7 @@ triggers.cpp \
 dbCommon.cpp \
 playerStats.cpp \
 failureLog.cpp \
+env.cpp \
 
 GAME_GRAPHICS = \
 

--- a/server/map.cpp
+++ b/server/map.cpp
@@ -21,6 +21,8 @@
 
 #include "dbCommon.h"
 
+#include "env.h"
+
 
 #include <stdarg.h>
 #include <math.h>
@@ -1200,12 +1202,14 @@ void initMap() {
         }
     
             
+    File mapDBFile( getEnvDBPath(), "map.db" );
+    const char *mapDBFileName = mapDBFile.getFullFileName();
 
     // note that the various decay ETA slots in map.db 
     // are define but unused, because we store times separately
     // in mapTime.db
-    int error = KISSDB_open( &db, 
-                             "map.db", 
+    int error = KISSDB_open( &db,
+                             mapDBFileName,
                              KISSDB_OPEN_MODE_RWCREAT,
                              80000,
                              16, // four 32-bit ints, xysb
@@ -1228,6 +1232,8 @@ void initMap() {
                              4 // one int, object ID at x,y in slot (s-3)
                                // OR contained count if s=2
                              );
+                             
+    delete [] mapDBFileName;
     
     if( error ) {
         AppLog::errorF( "Error %d opening map KissDB", error );
@@ -1236,13 +1242,14 @@ void initMap() {
     
     dbOpen = true;
 
-
+    File mapTimeDBFile( getEnvDBPath(), "mapTime.db" );
+    const char *mapTimeDBFileName = mapTimeDBFile.getFullFileName();
 
     // this DB uses the same slot numbers as the map.db
     // however, only times are stored here, because they require 8 bytes
     // so, slot 0 and 2 are never used, for example
-    error = KISSDB_open( &timeDB, 
-                         "mapTime.db", 
+    error = KISSDB_open( &timeDB,
+                         mapTimeDBFileName,
                          KISSDB_OPEN_MODE_RWCREAT,
                          80000,
                          16, // four 32-bit ints, xysb
@@ -1277,10 +1284,11 @@ void initMap() {
 
 
 
+    File biomeDBFile( getEnvDBPath(), "biome.db" );
+    const char *biomeDBFileName = biomeDBFile.getFullFileName();
 
-
-    error = KISSDB_open( &biomeDB, 
-                         "biome.db", 
+    error = KISSDB_open( &biomeDB,
+                         biomeDBFileName,
                          KISSDB_OPEN_MODE_RWCREAT,
                          80000,
                          8, // two 32-bit ints, xy
@@ -1291,6 +1299,8 @@ void initMap() {
                          //    multiplied by 1,000,000)
                          );
     
+    delete [] biomeDBFileName;
+    
     if( error ) {
         AppLog::errorF( "Error %d opening biome KissDB", error );
         return;
@@ -1300,15 +1310,18 @@ void initMap() {
 
 
 
+    File floorDBFile( getEnvDBPath(), "floor.db" );
+    const char *floorDBFileName = floorDBFile.getFullFileName();
 
-
-    error = KISSDB_open( &floorDB, 
-                         "floor.db", 
+    error = KISSDB_open( &floorDB,
+                         floorDBFileName,
                          KISSDB_OPEN_MODE_RWCREAT,
                          80000,
                          8, // two 32-bit ints, xy
                          4 // one int, the floor object ID at x,y 
                          );
+                         
+    delete [] floorDBFileName;
     
     if( error ) {
         AppLog::errorF( "Error %d opening floor KissDB", error );
@@ -1317,10 +1330,11 @@ void initMap() {
     
     floorDBOpen = true;
 
+    File floorTimeDBFile( getEnvDBPath(), "floorTime.db" );
+    const char *floorTimeDBFileName = floorTimeDBFile.getFullFileName();
 
-
-    error = KISSDB_open( &floorTimeDB, 
-                         "floorTime.db", 
+    error = KISSDB_open( &floorTimeDB,
+                         floorTimeDBFileName,
                          KISSDB_OPEN_MODE_RWCREAT,
                          80000,
                          8, // two 32-bit ints, xy
@@ -1328,6 +1342,8 @@ void initMap() {
                            // in whatever binary format and byte order
                            // "double" on the server platform uses
                          );
+    
+    delete [] floorTimeDBFileName;
     
     if( error ) {
         AppLog::errorF( "Error %d opening floor time KissDB", error );
@@ -1339,16 +1355,19 @@ void initMap() {
 
 
 
+    File eveDBFile( getEnvDBPath(), "eve.db" );
+    const char *eveDBFileName = eveDBFile.getFullFileName();
 
-
-    error = KISSDB_open( &eveDB, 
-                         "eve.db", 
+    error = KISSDB_open( &eveDB,
+                         eveDBFileName,
                          KISSDB_OPEN_MODE_RWCREAT,
                          80000,
                          50, // first 50 characters of email address
                              // append spaces to the end if needed 
                          12 // three ints,  x_center, y_center, radius
                          );
+                         
+    delete [] eveDBFileName;
     
     if( error ) {
         AppLog::errorF( "Error %d opening eve KissDB", error );

--- a/server/map.cpp
+++ b/server/map.cpp
@@ -1075,17 +1075,22 @@ int *getContainedRaw( int inX, int inY, int *outNumContained,
 
 
 void writeRecentPlacements() {
-    FILE *placeFile = fopen( "recentPlacements.txt", "w" );
-    if( placeFile != NULL ) {
+    File placeFile( getEnvDBPath(), "recentPlacements.txt" );
+    char *fullPath = placeFile.getFullFileName();
+
+    FILE *output = fopen( fullPath, "w" );
+    if( output != NULL ) {
         for( int i=0; i<NUM_RECENT_PLACEMENTS; i++ ) {
-            fprintf( placeFile, "%d,%d %d\n", recentPlacements[i].pos.x,
+            fprintf( output, "%d,%d %d\n", recentPlacements[i].pos.x,
                      recentPlacements[i].pos.y,
                      recentPlacements[i].depth );
             }
-        fprintf( placeFile, "nextPlacementIndex=%d\n", nextPlacementIndex );
+        fprintf( output, "nextPlacementIndex=%d\n", nextPlacementIndex );
         
-        fclose( placeFile );
+        fclose( output );
         }
+
+    delete [] fullPath;
     }
 
 

--- a/server/playerStats.cpp
+++ b/server/playerStats.cpp
@@ -2,6 +2,7 @@
 
 #include "kissdb.h"
 #include "dbCommon.h"
+#include "env.h"
 
 #include "minorGems/util/log/AppLog.h"
 #include "minorGems/util/SettingsManager.h"
@@ -9,6 +10,8 @@
 
 #include "minorGems/network/web/WebRequest.h"
 #include "minorGems/network/web/URLUtils.h"
+
+#include "minorGems/io/file/File.h"
 
 #include "minorGems/crypto/hashes/sha1.h"
 
@@ -37,14 +40,19 @@ static SimpleVector<StatRecord> records;
 
 
 void initPlayerStats() {
-    int error = KISSDB_open( &db, 
-                             "playerStats.db", 
+    File playerStatsDBFile( getEnvDBPath(), "playerStats.db" );
+    const char *playerStatsDBFileName = playerStatsDBFile.getFullFileName();
+  
+    int error = KISSDB_open( &db,
+                             playerStatsDBFileName,
                              KISSDB_OPEN_MODE_RWCREAT,
                              80000,
                              50, // first 50 characters of email address
                                  // append spaces to the end if needed 
                              8   // two ints,  num_lives, total_seconds
                              );
+                             
+    delete [] playerStatsDBFileName;
     
     if( error ) {
         AppLog::errorF( "Error %d opening eve KissDB", error );

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -27,6 +27,8 @@
 
 #include "minorGems/formats/encodingUtils.h"
 
+#include "minorGems/io/file/File.h"
+
 
 #include "map.h"
 #include "../gameSource/transitionBank.h"
@@ -34,6 +36,7 @@
 #include "../gameSource/animationBank.h"
 #include "../gameSource/categoryBank.h"
 
+#include "env.h"
 #include "lifeLog.h"
 #include "foodLog.h"
 #include "backup.h"
@@ -3483,12 +3486,19 @@ static void sendMessageToPlayer( LiveObject *inPlayer,
 
 int main() {
 
+    readEnv();
+
     nextID = 
         SettingsManager::getIntSetting( "nextPlayerID", 2 );
 
 
     // make backup and delete old backup every three days
-    AppLog::setLog( new FileLog( "log.txt", 259200 ) );
+    File logFile( getEnvLogPath(), "log.txt" );
+    char *logFileName = logFile.getFullFileName();
+    printf( "Outputting to %s\n", logFileName );
+    
+    AppLog::setLog( new FileLog( logFileName, 259200 ) );
+    delete [] logFileName;
 
     AppLog::setLoggingLevel( Log::DETAIL_LEVEL );
     AppLog::printAllMessages( true );
@@ -3497,6 +3507,14 @@ int main() {
     AppLog::info( "Server starting up" );
 
     printf( "\n" );
+    
+    Path *settingsPath = getEnvSettingsPath();
+    if (settingsPath != NULL) {
+        char *settingsPathName = settingsPath->getPathStringTerminated();
+        SettingsManager::setDirectoryName(settingsPathName);
+        
+        delete [] settingsPathName;
+        }
     
     initLifeLog();
     initBackup();

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -2477,9 +2477,16 @@ static LiveObject *getHitPlayer( int inX, int inY,
     }
 
     
+static void writeNextPlayerID() {
+    File nextPlayerIDFile( getEnvDBPath(), "nextPlayerID.txt" );
+    nextPlayerIDFile.writeToFile( nextID );
+    }
 
 
-        
+static void writeNextSequenceNumber() {
+    File nextSequenceNumberFile( getEnvDBPath(), "nextSequenceNumber.txt" );
+    nextSequenceNumberFile.writeToFile( nextSequenceNumber );
+    }
 
 
 void processLoggedInPlayer( Socket *inSock,
@@ -2511,9 +2518,7 @@ void processLoggedInPlayer( Socket *inSock,
     
     newObject.id = nextID;
     nextID++;
-
-    SettingsManager::setSetting( "nextPlayerID",
-                                 (int)nextID );
+    writeNextPlayerID();
 
 
     newObject.responsiblePlayerID = -1;
@@ -3485,12 +3490,13 @@ static void sendMessageToPlayer( LiveObject *inPlayer,
 
 
 int main() {
-
     readEnv();
 
-    nextID = 
-        SettingsManager::getIntSetting( "nextPlayerID", 2 );
+    File nextPlayerIDFile( getEnvDBPath(), "nextPlayerID.txt" );
+    nextID = nextPlayerIDFile.readFileIntContents(2);
 
+    File nextSequenceNumberFile( getEnvDBPath(), "nextSequenceNumber.txt" );
+    nextSequenceNumber = nextSequenceNumberFile.readFileIntContents(1);
 
     // make backup and delete old backup every three days
     File logFile( getEnvLogPath(), "log.txt" );
@@ -3520,10 +3526,6 @@ int main() {
     initBackup();
     
     initPlayerStats();
-    
-
-    nextSequenceNumber = 
-        SettingsManager::getIntSetting( "sequenceNumber", 1 );
 
     requireClientPassword =
         SettingsManager::getIntSetting( "requireClientPassword", 1 );
@@ -3834,9 +3836,7 @@ int main() {
                 newConnection.sequenceNumber = nextSequenceNumber;
                 
                 nextSequenceNumber ++;
-                
-                SettingsManager::setSetting( "sequenceNumber",
-                                             (int)nextSequenceNumber );
+                writeNextSequenceNumber();
                 
                 char *message;
                 
@@ -8409,4 +8409,3 @@ void startOutputAllFrames() {
 
 void stopOutputAllFrames() {
     }
-


### PR DESCRIPTION
This allows configuration of paths for a server with three environment variables:

 - `OHOL_LOG_PATH`: where `log.txt`, `foodLog`, `failureLog`, etc go
 - `OHOL_DB_PATH`: where kissdb files are stored, along with `recentPlacements.txt`, `nextPlayerID.txt`, and `nextSequenceNumber.txt` (see below)
 - `OHOL_SETTINGS_PATH`: where setting files are read from

For my custom server, I'd like to set these to something like `/var/ohol/logs`, `/var/ohol/db`, and `/etc/ohol`, respectively. This would solve a few problems. For one, it would be easier to update without having to stash/unstash server settings (right now if you change the port, and then run `pullAndBuildLatest`, it wipes your settings). Second, it'd remove (most of) the cruft in the server directory, which also interferes with git (this is separately mitigated by #13; I ran `git clean -f` earlier while updating, and nearly wiped my server, which is what prompted these PRs). Finally, it's a step towards the ultimate goal being able to have the binary work without write access to the directory where it lives (for my sanity 😄 ).

As a related change, it also moves `nextPlayerID.ini` and `nextSequenceNumber.ini` to text files in the db path (or the working directory).