### PR TITLE
Position patches

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -15889,11 +15889,17 @@ void LivingLifePage::step() {
                                 o->waypointY = lrint( worldMouseY / CELL_D );
 
                                 pointerDown( fakeClick.x, fakeClick.y );
+
+                                endPos.x = (double)( fakeClick.x );
+                                endPos.y = (double)( fakeClick.y );
                                
                                 o->useWaypoint = false;
                                 }
                             else {
                                 pointerDown( worldMouseX, worldMouseY );
+
+                                endPos.x = (double)( worldMouseX );
+                                endPos.y = (double)( worldMouseY );
                                 }
                             }
                         }

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -12418,6 +12418,14 @@ void LivingLifePage::step() {
                             existing->xd = o.xd;
                             existing->yd = o.yd;
                             existing->destTruncated = false;
+
+                            // clear an existing path, since they may no
+                            // longer be on it
+                            if( existing->pathToDest != NULL ) {
+                                delete [] existing->pathToDest;
+                                existing->pathToDest = NULL;
+                                }
+
                             }
                         existing->outOfRange = false;
 
@@ -13249,6 +13257,13 @@ void LivingLifePage::step() {
                             existing->xd = o.xd;
                             existing->yd = o.yd;
                             existing->destTruncated = false;
+
+                            // clear an existing path, since they may no
+                            // longer be on it
+                            if( existing->pathToDest != NULL ) {
+                                delete [] existing->pathToDest;
+                                existing->pathToDest = NULL;
+                                }
 
                             if( existing->lastHeldByRawPosSet ) {    
                                 existing->heldByDropOffset =

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -1387,6 +1387,60 @@ void updateMoveSpeed( LiveObject *inObject ) {
     }
 
 
+
+static void fixupSingularPath( LiveObject *inObject ) {
+    if( inObject->pathLength != 1 ) return;
+
+    printf("%d fixup for overtruncated path\n", inObject->id);
+    
+    // trimmed path too short
+    // needs to have at least
+    // a start and end pos
+    
+    // give it an artificial
+    // start pos
+    
+
+    doublePair nextWorld =
+        gridToDouble( 
+         inObject->pathToDest[0] );
+
+    
+    doublePair vectorAway;
+
+    if( ! equal( 
+            inObject->currentPos,
+            nextWorld ) ) {
+            
+        vectorAway = normalize(
+            sub( 
+                inObject->
+                currentPos,
+                nextWorld ) );
+        }
+    else {
+        vectorAway.x = 1;
+        vectorAway.y = 0;
+        }
+    
+    GridPos oldPos =
+        inObject->pathToDest[0];
+    
+    delete [] inObject->pathToDest;
+    inObject->pathLength = 2;
+    
+    inObject->pathToDest =
+        new GridPos[2];
+    inObject->pathToDest[0].x =
+        oldPos.x + vectorAway.x;
+    inObject->pathToDest[0].y =
+        oldPos.y + vectorAway.y;
+    
+    inObject->pathToDest[1] =
+        oldPos;
+    }
+
+
 // should match limit on server
 static int pathFindingD = 32;
 
@@ -12241,6 +12295,10 @@ void LivingLifePage::step() {
                                         break;
                                         }
                                     }
+
+                                if( existing->pathLength == 1 ) {
+                                    fixupSingularPath( existing );
+                                    }
                                 }
                             }
 
@@ -14211,52 +14269,7 @@ void LivingLifePage::step() {
                                                        existing->pathLength );
 
                                             if( existing->pathLength == 1 ) {
-                                                
-                                                // trimmed path too short
-                                                // needs to have at least
-                                                // a start and end pos
-                                                
-                                                // give it an artificial
-                                                // start pos
-                                                
-
-                                                doublePair nextWorld =
-                                                    gridToDouble( 
-                                                     existing->pathToDest[0] );
-
-                                                
-                                                doublePair vectorAway;
-
-                                                if( ! equal( 
-                                                        existing->currentPos,
-                                                        nextWorld ) ) {
-                                                        
-                                                    vectorAway = normalize(
-                                                        sub( 
-                                                            existing->
-                                                            currentPos,
-                                                            nextWorld ) );
-                                                    }
-                                                else {
-                                                    vectorAway.x = 1;
-                                                    vectorAway.y = 0;
-                                                    }
-                                                
-                                                GridPos oldPos =
-                                                    existing->pathToDest[0];
-                                                
-                                                delete [] existing->pathToDest;
-                                                existing->pathLength = 2;
-                                                
-                                                existing->pathToDest =
-                                                    new GridPos[2];
-                                                existing->pathToDest[0].x =
-                                                    oldPos.x + vectorAway.x;
-                                                existing->pathToDest[0].y =
-                                                    oldPos.y + vectorAway.y;
-                                                
-                                                existing->pathToDest[1] =
-                                                    oldPos;
+                                                fixupSingularPath( existing );
                                                 }
                                             
                                             


### PR DESCRIPTION
## Fix for automatic clicks happening just before stopping movement.

The code for continuous running (mouse hold) runs just before the
end-of-move detection, so it possible to have an automatic move occur as
the character reaches their current destination, resulting in the
character stopped with an outstanding path (which had been sent to server)
and destination position different than current position.

Updating the move end position prevents the later code from immediately
ending movement.

I caught this in a short replay, although I was using my own custom
auto-run trigger, which used the same automatic clicking code.

## Fix up over-truncation in player update.

I believe this fixes draw inversion, and perhaps unable to pickup baby, due
to player position discrepancy on the client. It was possible for truncation
of paths during PLAYER_UPDATE to leave a single step path after truncation,
which the code elsewhere takes steps to prevent. The path execution code
will use the next path location without checking length, causing it to path
beyond the current destination position.

This patch extracts a function from the code which fixes up over-truncated
paths during PLAYER_MOVE in order to use it during PLAYER_UPDATE.


## Additional player path clears.

These are less certain to be issues, but I discovered possible path and
destination discrepancies while investigating position issues. This add some
additional path resets where current and destination positions were forced.