### PR TITLE
Biomes appear correctly in MAP_CHUNK messages.

### DIFF
--- a/server/map.cpp
+++ b/server/map.cpp
@@ -1026,7 +1026,9 @@ static int getBaseMap( int inX, int inY ) {
             return 0;
             }
         
-        lastCheckedBiome = biomes[pickedBiome];
+        if (lastCheckedBiome == -1) {
+            lastCheckedBiome = biomes[pickedBiome];
+            }
         
 
         


### PR DESCRIPTION
Fixes #245

Underlying issue was that getMapObject and getMapObjectRaw may make other calls to getBaseMap at different locations, overriding lastCheckedBiome. Either because checking for wide objects or checking the heights of nearby objects or through checkDecayObject.