### PR TITLE
Fix continuous run overextension

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -17020,17 +17020,11 @@ void LivingLifePage::step() {
                                 o->waypointY = lrint( worldMouseY / CELL_D );
 
                                 pointerDown( fakeClick.x, fakeClick.y );
-
-                                endPos.x = (double)( fakeClick.x );
-                                endPos.y = (double)( fakeClick.y );
                                
                                 o->useWaypoint = false;
                                 }
                             else {
                                 pointerDown( worldMouseX, worldMouseY );
-
-                                endPos.x = (double)( worldMouseX );
-                                endPos.y = (double)( worldMouseY );
                                 }
                             }
                         }


### PR DESCRIPTION
So, sorry about the bad patch earlier. You got to it before I was
satisfied with further testing. I had realized that the path extension
was using the wrong coordinate system - pixel space not tile space. It
was also using the end of the path as a cheap way to get a point far
enough out to skip the following end-of-path check.

I'm pretty sure this causes an occasional single frame flip of the
character draw orientation when running contiuously in certain relative
map positions.

The change you made to check for minium distance should also fix the
original issue. Given that this should prevent the problem case, the
simplist fix is to remove the endpoint reset.