### PR TITLE
Fixed eve location jumped by donkeytown bugs.

### DIFF
--- a/scripts/remoteServerWipeMap.sh
+++ b/scripts/remoteServerWipeMap.sh
@@ -70,6 +70,7 @@ then
 	rm ~/checkout/OneLife/server/eveRadius.txt
 	rm ~/checkout/OneLife/server/mapDummyRecall.txt
 	rm ~/checkout/OneLife/server/lastEveLocation.txt
+	rm ~/checkout/OneLife/server/lastDonkeytownLocation.txt
 	rm ~/checkout/OneLife/server/biomeRandSeed.txt
 
 	echo "0,0" > ~/checkout/OneLife/server/shutdownLongLineagePos.txt

--- a/server/eveMovingGrid.cpp
+++ b/server/eveMovingGrid.cpp
@@ -44,11 +44,6 @@ void getEveMovingGridPosition( int *inOutX, int *inOutY ) {
         }    
     
 
-    File eveLocFile( NULL, "lastEveLocation.txt" );
-    char *locString = autoSprintf( "%d,%d", newX, newY );
-    eveLocFile.writeToFile( locString );
-    delete [] locString;
-
     *inOutX = newX;
     *inOutY = newY;
     }

--- a/server/map.h
+++ b/server/map.h
@@ -62,7 +62,7 @@ void resetEveRadius();
 // considered.
 void getEvePosition( const char *inEmail, int inID, int *outX, int *outY,
                      SimpleVector<GridPos> *inOtherPeoplePos,
-                     char inAllowRespawn = true );
+                     char inAllowRespawn = true, int inCurseLevel = 0 );
 
 
 // save recent placements on Eve's death so that this player can spawn
@@ -295,7 +295,7 @@ int getMapObjectRaw( int inX, int inY );
 // from leaving (though flights from outside are unrestriced)
 GridPos getNextFlightLandingPos( int inCurrentX, int inCurrentY,
                                  doublePair inDir,
-                                 int inRadiusLimit = -1 );
+                                 int inRadiusLimit = -1, int inCurseLevel = 0 );
 
 
 

--- a/server/runServerCleanMap.sh
+++ b/server/runServerCleanMap.sh
@@ -1,3 +1,3 @@
 echo 1 > testMapStale.txt
-rm *.db mapDummyRecall.txt shutdownLongLineagePos.txt lastEveLocation.txt; make; ./OneLifeServer
+rm *.db mapDummyRecall.txt shutdownLongLineagePos.txt lastEveLocation.txt lastDonkeytownLocation.txt; make; ./OneLifeServer
 

--- a/server/runServerTestMap.sh
+++ b/server/runServerTestMap.sh
@@ -1,6 +1,6 @@
 if [ -f ../gameSource/testMap.txt ]
 then
-	rm *.db curseSave.txt mapDummyRecall.txt testMapStale.txt shutdownLongLineagePos.txt lastEveLocation.txt; cp ../gameSource/testMap.txt .; make; ./OneLifeServer
+	rm *.db curseSave.txt mapDummyRecall.txt testMapStale.txt shutdownLongLineagePos.txt lastEveLocation.txt lastDonkeytownLocation.txt; cp ../gameSource/testMap.txt .; make; ./OneLifeServer
 else
 	echo "testMap.txt does not exist in ../gameSource"
 fi

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -8592,25 +8592,8 @@ int processLoggedInPlayer( char inAllowReconnect,
         int startX, startY;
         getEvePosition( newObject.email, 
                         newObject.id, &startX, &startY, 
-                        &otherPeoplePos, allowEveRespawn );
+                        &otherPeoplePos, allowEveRespawn, inCurseStatus.curseLevel );
 
-        if( inCurseStatus.curseLevel > 0 ) {
-            // keep cursed players away
-
-            // 20K away in X and 20K away in Y, pushing out away from 0
-            // in both directions
-
-            if( startX > 0 )
-                startX += 20000;
-            else
-                startX -= 20000;
-            
-            if( startY > 0 )
-                startY += 20000;
-            else
-                startY -= 20000;
-            }
-        
 
         if( SettingsManager::getIntSetting( "forceEveLocation", 0 ) ) {
 
@@ -20603,7 +20586,8 @@ int main() {
                                         nextPlayer->xs,
                                         nextPlayer->ys,
                                         takeOffDir,
-                                        radiusLimit );
+                                        radiusLimit,
+                                        nextPlayer->curseStatus.curseLevel );
                                     
                                     AppLog::infoF( 
                                     "Player %d non-map flight taking off "


### PR DESCRIPTION
From:
https://github.com/jasonrohrer/OneLife/issues/442

Public birth data statistics:
https://onehouronelife.com/forums/viewtopic.php?pid=81388#p81388

Eve location had change when donkeytown player logged in.
So, I made "lastDonkeytownLocation.txt" and if curseLeve > 0, use donkeytownLocation.

This prevent glitch of "Donkey player can fly to normal eve grid position with airplane".
Now, donkeytown player fly to donkeytown's eve location.

This pull request made with this suggestion.
https://onehouronelife.com/forums/viewtopic.php?id=8614