### PR TITLE
Fixed eve location jumped by tutorial twins bugs.

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -8535,6 +8535,19 @@ int processLoggedInPlayer( char inAllowReconnect,
             }
         }
     
+    if( inForcePlayerPos != NULL ) {
+        placed = true;
+
+        int startX = inForcePlayerPos->x;
+        int startY = inForcePlayerPos->y;
+        
+        newObject.xs = startX;
+        newObject.ys = startY;
+        
+        newObject.xd = startX;
+        newObject.yd = startY;
+        }
+    
     
     if( !placed ) {
         // tutorial didn't happen if not placed
@@ -8637,21 +8650,6 @@ int processLoggedInPlayer( char inAllowReconnect,
         newObject.displayID = inForceDisplayID;
         }
 
-    if( inForcePlayerPos != NULL ) {
-        int startX = inForcePlayerPos->x;
-        int startY = inForcePlayerPos->y;
-        
-        newObject.xs = startX;
-        newObject.ys = startY;
-        
-        newObject.xd = startX;
-        newObject.yd = startY;
-
-        if( newObject.xs > maxPlacementX ) {
-            maxPlacementX = newObject.xs;
-            }
-        }
-    
 
     
     if( parent == NULL ) {


### PR DESCRIPTION
From:
https://github.com/jasonrohrer/OneLife/issues/442

Public birth data.
https://onehouronelife.com/forums/viewtopic.php?pid=81388#p81388

Second player of tutorial's twins player moved eve location to next.
And tutorial area(maxPlacementX) moved to 400000(tutorialOffsetX) far east from source tutorial position.

This pull request made with this suggestion.
https://onehouronelife.com/forums/viewtopic.php?id=8614