### PR TITLE
No longer over feeding. Fixes #466

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -18290,7 +18290,7 @@ int main() {
                                 // instead, stick to the food cap shown
                                 // in the client (what we last reported
                                 // to them)
-                                int cap = nextPlayer->lastReportedFoodCapacity;
+                                int cap = targetPlayer->lastReportedFoodCapacity;
                                 
 
                                 // first case:


### PR DESCRIPTION
From:
https://github.com/jasonrohrer/OneLife/issues/466
https://onehouronelife.com/forums/viewtopic.php?id=8656

Big cap's adult feed small cap's child is always allowed without hungry.