### PR TITLE
Assign the person that named the baby as its leader

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -8931,8 +8931,8 @@ int processLoggedInPlayer( char inAllowReconnect,
 
         newObject.lineageEveID = parent->lineageEveID;
 
-        // child inherits mother's leader
-        newObject.followingID = parent->followingID;
+        // consider the baby abandoned until it has a name
+        newObject.followingID = -1;
         
 
         newObject.parentChainLength = parent->parentChainLength + 1;
@@ -17645,6 +17645,9 @@ int main() {
                                                              &( m.saidText ),
                                                              babyO );
                                     }
+                                    
+                                    // assume that whoever named the baby is taking care of them
+                                    baby->followingID = nextPlayer->id;
                                 }
                             }
                         else {
@@ -17698,6 +17701,9 @@ int main() {
                                             &( m.saidText ),
                                             closestOther, false );
                                         }
+                                        
+                                        // assume that whoever named the baby is taking care of them
+                                        baby->followingID = nextPlayer->id;
                                     }
                                 }
 


### PR DESCRIPTION
This makes babies follow the person that named them.

Naming happens only once at most, and sometimes not at all.

Most of the time mothers name their children. But sometimes children are taken care of by their aunts, uncles, or strangers.

Naming a child takes a bit of effort and proves that the person is at least paying attention to the child.