### PR TITLE
Fix ghost horses and other sounds.

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -20864,7 +20864,7 @@ void LivingLifePage::step() {
             o->heldFrozenRotFrameCount += animSpeed / BASE_SPEED;
             }
         
-        if( o->holdingID > 0 ) {
+        if( o->holdingID > 0 && ! o->outOfRange ) {
             handleAnimSound( o->id,
                              o->holdingID, 0, o->curHeldAnim,
                              oldFrameCount, o->heldAnimationFrameCount,


### PR DESCRIPTION
Sounds caused by held objects were not properly excluded for out of
range players.

My test reproduction:

Player A grabs a horse cart and runs around until they get stuck in a running animation on player B's screen.
Player B walks a long distance east.
Player A rides a long distance west.
Player B returns to the start location.

Sound is playing before patch, not playing with patch.