### PR TITLE
Fix crash on leader death with no fitness server

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -15455,7 +15455,7 @@ static void leaderDied( LiveObject *inLeader ) {
     if( inLeader->followingID == -1 &&
         directFollowers.size() > 0 ) {
         
-        LiveObject *fittestFollower = NULL;
+        LiveObject *fittestFollower = directFollowers.getElementDirect( 0 );
         double fittestFitness = 0;
         
         for( int i=0; i<directFollowers.size(); i++ ) {


### PR DESCRIPTION
With no fitness server, genetic scores are negative, thus no follower is
selected with fitness > 0 and fittestFollower remains null. To prevent
this, we select an aribrary follower as default value.

Fixes #670 