### PR TITLE
Link contentSettings folder in linux server pull and setup script.

### DIFF
--- a/server/installYourOwnServer/serverPullAndBuildLinux.sh
+++ b/server/installYourOwnServer/serverPullAndBuildLinux.sh
@@ -42,6 +42,7 @@ ln -s ../../OneLifeData7/transitions .
 ln -s ../../OneLifeData7/categories .
 ln -s ../../OneLifeData7/tutorialMaps .
 ln -s ../../OneLifeData7/dataVersionNumber.txt .
+ln -s ../../OneLifeData7/contentSettings .
 
 git for-each-ref --sort=-creatordate --format '%(refname:short)' --count=2 refs/tags | grep "OneLife_v" | sed -e 's/OneLife_v//' > serverCodeVersionNumber.txt
 


### PR DESCRIPTION
Several server features, especially map generation, behave really weird without access to the OneLifeData7 content settings. This link fixes the problem in accordance to the existing references to OneLifeData7.