### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/gameSource/stb_vorbis.c
+++ b/gameSource/stb_vorbis.c
@@ -2011,7 +2011,7 @@ static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y
    ady -= abs(base) * adx;
    if (x1 > n) x1 = n;
    if (x < x1) {
-      LINE_OP(output[x], inverse_db_table[y]);
+      LINE_OP(output[x], inverse_db_table[y&255]);
       for (++x; x < x1; ++x) {
          err += ady;
          if (err >= adx) {
@@ -2019,7 +2019,7 @@ static __forceinline void draw_line(float *output, int x0, int y0, int x1, int y
             y += sy;
          } else
             y += base;
-         LINE_OP(output[x], inverse_db_table[y]);
+         LINE_OP(output[x], inverse_db_table[y&255]);
       }
    }
 }


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function draw_line() in `gameSource/stb_vorbis.c` sourced from [nothings/stb](https://github.com/nothings/stb). This issue, originally reported in [CVE-2019-13222](https://nvd.nist.gov/vuln/detail/CVE-2019-13222), was resolved in the repository via this commit https://github.com/nothings/stb/commit/98fdfc6df88b1e34a736d5e126e6c8139c8de1a6.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!