### PR TITLE
Fix heap buffer overflow in start_decoder()

### DIFF
--- a/gameSource/stb_vorbis.c
+++ b/gameSource/stb_vorbis.c
@@ -1200,8 +1200,10 @@ static int lookup1_values(int entries, int dim)
    int r = (int) floor(exp((float) log((float) entries) / dim));
    if ((int) floor(pow((float) r+1, dim)) <= entries)   // (int) cast for MinGW warning;
       ++r;                                              // floor() to avoid _ftol() when non-CRT
-   assert(pow((float) r+1, dim) > entries);
-   assert((int) floor(pow((float) r, dim)) <= entries); // (int),floor() as above
+   if (pow((float) r+1, dim) <= entries)
+      return -1;
+   if ((int) floor(pow((float) r, dim)) > entries)
+      return -1;
    return r;
 }
 
@@ -3671,6 +3673,7 @@ static int start_decoder(vorb *f)
          while (current_entry < c->entries) {
             int limit = c->entries - current_entry;
             int n = get_bits(f, ilog(limit));
+            if (current_length >= 32) return error(f, VORBIS_invalid_setup);
             if (current_entry + n > (int) c->entries) { return error(f, VORBIS_invalid_setup); }
             memset(lengths + current_entry, current_length, n);
             current_entry += n;


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function start_decoder() in `gameSource/stb_vorbis.c` sourced from [nothings/stb](https://github.com/nothings/stb). This issue, originally reported in [CVE-2019-13217](https://nvd.nist.gov/vuln/detail/CVE-2019-13217), was resolved in the repository via this commit https://github.com/nothings/stb/commit/98fdfc6df88b1e34a736d5e126e6c8139c8de1a6.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!